### PR TITLE
修正作者列表

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "description": "聊天界面，右键点击文本消息，选择【编辑消息内容】编辑即可",
     "version": "1.0.8",
     "icon": "./icon.png",
-    "author": [{
+    "authors": [{
             "name": "MIMO",
             "link": "https://github.com/mimocvb"
         }, {


### PR DESCRIPTION
正确的名字是 authors，在不正确的情况下如果使用插件加载器 1.2.0 以前的版本的话会导致插件列表不完整。1.2.0 后可以加载完整插件列表但这个插件的作者栏位仍然是空的